### PR TITLE
Added configPath option, use cover instead of crop for splash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,292 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "ajv": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-            "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+        "@babel/polyfill": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
+            "integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "core-js": "^2.5.7",
+                "regenerator-runtime": "^0.11.1"
+            }
+        },
+        "@jimp/bmp": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.5.4.tgz",
+            "integrity": "sha512-P/ezH1FuoM3FwS0Dm2ZGkph4x5/rPBzFLEZor7KQkmGUnYEIEG4o0BUcAWFmJOp2HgzbT6O2SfrpJNBOcVACzQ==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "bmp-js": "^0.1.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/core": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.5.4.tgz",
+            "integrity": "sha512-n3uvHy2ndUKItmbhnRO8xmU8J6KR+v6CQxO9sbeUDpSc3VXc1PkqrA8ZsCVFCjnDFcGBXL+MJeCTyQzq5W9Crw==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "any-base": "^1.1.0",
+                "buffer": "^5.2.0",
+                "core-js": "^2.5.7",
+                "exif-parser": "^0.1.12",
+                "file-type": "^9.0.0",
+                "load-bmfont": "^1.3.1",
+                "mkdirp": "0.5.1",
+                "phin": "^2.9.1",
+                "pixelmatch": "^4.0.2",
+                "tinycolor2": "^1.4.1"
+            }
+        },
+        "@jimp/custom": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.5.4.tgz",
+            "integrity": "sha512-tLfyJoyouDl2J3RPFGfDzTtE+4S8ljqJUmLzy/cmx1n7+xS5TpLPdPskp7UaeAfNTqdF4CNAm94KYoxTZdj2mg==",
+            "requires": {
+                "@jimp/core": "^0.5.4",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/gif": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.5.0.tgz",
+            "integrity": "sha512-HVB4c7b8r/yCpjhCjVNPRFLuujTav5UPmcQcFJjU6aIxmne6e29rAjRJEv3UMamHDGSu/96PzOsPZBO5U+ZGww==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7",
+                "omggif": "^1.0.9"
+            }
+        },
+        "@jimp/jpeg": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.5.4.tgz",
+            "integrity": "sha512-YaPWm+YSGCThNE/jLMckM3Qs6uaMxd/VsHOnEaqu5tGA4GFbfVaWHjKqkNGAFuiNV+HdgKlNcCOF3of+elvzqQ==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7",
+                "jpeg-js": "^0.3.4"
+            }
+        },
+        "@jimp/plugin-blit": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.5.4.tgz",
+            "integrity": "sha512-WqDYOugv76hF1wnKy7+xPGf9PUbcm9vPW28/jHWn1hjbb2GnusJ2fVEFad76J/1SPfhrQ2Uebf2QCWJuLmOqZg==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-blur": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.5.0.tgz",
+            "integrity": "sha512-5k0PXCA1RTJdITL7yMAyZ5tGQjKLHqFvwdXj/PCoBo5PuMyr0x6qfxmQEySixGk/ZHdDxMi80vYxHdKHjNNgjg==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-color": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.5.4.tgz",
+            "integrity": "sha512-63bjkqj2N/QtaYwOwG1OctrIMTYmZl0eSh0+EFy28Y302wp1u606RD++rhHtOml4wP2R6VPzLmHCV9JxA+tgwA==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7",
+                "tinycolor2": "^1.4.1"
+            }
+        },
+        "@jimp/plugin-contain": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.5.4.tgz",
+            "integrity": "sha512-8YJh4FI3S69unri0nJsWeqVLeVGA77N2R0Ws16iSuCCD/5UnWd9FeWRrSbKuidBG6TdMBaG2KUqSYZeHeH9GOQ==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-cover": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.5.4.tgz",
+            "integrity": "sha512-2Rur7b44WiDDgizUI2M2uYWc1RmfhU5KjKS1xXruobjQ0tXkf5xlrPXSushq0hB6Ne0Ss6wv0+/6eQ8WeGHU2w==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-crop": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.5.4.tgz",
+            "integrity": "sha512-6t0rqn4VazquGk48tO6hFBrQ+nkvC+A1RnR6UM/m8ZtG2/yjpwF0MXcpgJI1Fb+a4Ug7BY1fu2GPcZOhnAVK/g==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-displace": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.5.0.tgz",
+            "integrity": "sha512-Bec7SQvnmKia4hOXEDjeNVx7vo/1bWqjuV6NO8xbNQcAO3gaCl91c9FjMDhsfAVb0Ou6imhbIuFPrLxorXsecQ==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-dither": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.5.0.tgz",
+            "integrity": "sha512-We2WJQsD/Lm8oqBFp/vUv9/5r2avyenL+wNNu/s2b1HqA5O4sPGrjHy9K6vIov0NroQGCQ3bNznLkTmjiHKBcg==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-flip": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.5.0.tgz",
+            "integrity": "sha512-D/ehBQxLMNR7oNd80KXo4tnSET5zEm5mR70khYOTtTlfti/DlLp3qOdjPOzfLyAdqO7Ly4qCaXrIsnia+pfPrA==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-gaussian": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.5.0.tgz",
+            "integrity": "sha512-Ln4kgxblv0/YzLBDb/J8DYPLhDzKH87Y8yHh5UKv3H+LPKnLaEG3L4iKTE9ivvdocnjmrtTFMYcWv2ERSPeHcg==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-invert": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.5.0.tgz",
+            "integrity": "sha512-/vyKeIi3T7puf+8ruWovTjzDC585EnTwJ+lGOOUYiNPsdn4JDFe1B3xd+Ayv9aCQbXDIlPElZaM9vd/+wqDiIQ==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-mask": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.5.4.tgz",
+            "integrity": "sha512-mUJ04pCrUWaJGXPjgoVbzhIQB8cVobj2ZEFlGO3BEAjyylYMrdJlNlsER8dd7UuJ2L/a4ocWtFDdsnuicnBghQ==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-normalize": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.5.4.tgz",
+            "integrity": "sha512-Q5W0oEz9wxsjuhvHAJynI/OqXZcmqEAuRONQId7Aw5ulCXSOg9C4y2a67EO7aZAt55T+zMVxI9UpVUpzVvO6hw==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-print": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.5.4.tgz",
+            "integrity": "sha512-DOZr5TY9WyMWFBD37oz7KpTEBVioFIHQF/gH5b3O5jjFyj4JPMkw7k3kVBve9lIrzIYrvLqe0wH59vyAwpeEFg==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7",
+                "load-bmfont": "^1.4.0"
+            }
+        },
+        "@jimp/plugin-resize": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.5.4.tgz",
+            "integrity": "sha512-lXNprNAT0QY1D1vG/1x6urUTlWuZe2dfL29P81ApW2Yfcio471+oqo45moX5FLS0q24xU600g7cHGf2/TzqSfA==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-rotate": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.5.4.tgz",
+            "integrity": "sha512-SIdUpMc8clObMchy8TnjgHgcXEQM992z5KavgiuOnCuBlsmSHtE3MrXTOyMW0Dn3gqapV9Y5vygrLm/BVtCCsg==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugin-scale": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.5.0.tgz",
+            "integrity": "sha512-5InIOr3cNtrS5aQ/uaosNf28qLLc0InpNGKFmGFTv8oqZqLch6PtDTjDBZ1GGWsPdA/ljy4Qyy7mJO1QBmgQeQ==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7"
+            }
+        },
+        "@jimp/plugins": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.5.4.tgz",
+            "integrity": "sha512-lVyxtO5rgrp4ghXHMPOpwogCTAfcNSHTG23oH5g4D2EDnfP+GnM/Zxpsjo8A4TE0jS+jgrnTLljDsalEZgA4QQ==",
+            "requires": {
+                "@jimp/plugin-blit": "^0.5.4",
+                "@jimp/plugin-blur": "^0.5.0",
+                "@jimp/plugin-color": "^0.5.4",
+                "@jimp/plugin-contain": "^0.5.4",
+                "@jimp/plugin-cover": "^0.5.4",
+                "@jimp/plugin-crop": "^0.5.4",
+                "@jimp/plugin-displace": "^0.5.0",
+                "@jimp/plugin-dither": "^0.5.0",
+                "@jimp/plugin-flip": "^0.5.0",
+                "@jimp/plugin-gaussian": "^0.5.0",
+                "@jimp/plugin-invert": "^0.5.0",
+                "@jimp/plugin-mask": "^0.5.4",
+                "@jimp/plugin-normalize": "^0.5.4",
+                "@jimp/plugin-print": "^0.5.4",
+                "@jimp/plugin-resize": "^0.5.4",
+                "@jimp/plugin-rotate": "^0.5.4",
+                "@jimp/plugin-scale": "^0.5.0",
+                "core-js": "^2.5.7",
+                "timm": "^1.6.1"
+            }
+        },
+        "@jimp/png": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.5.4.tgz",
+            "integrity": "sha512-J2NU7368zihF1HUZdmpXsL/Hhyf+I3ubmK+6Uz3Uoyvtk1VS7dO3L0io6fJQutfWmPZ4bvu6Ry022oHjbi6QCA==",
+            "requires": {
+                "@jimp/utils": "^0.5.0",
+                "core-js": "^2.5.7",
+                "pngjs": "^3.3.3"
+            }
+        },
+        "@jimp/tiff": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.5.4.tgz",
+            "integrity": "sha512-hr7Zq3eWjAZ+itSwuAObIWMRNv7oHVM3xuEDC2ouP7HfE7woBtyhCyfA7u12KlgtM57gKWeogXqTlewRGVzx6g==",
+            "requires": {
+                "core-js": "^2.5.7",
+                "utif": "^2.0.1"
+            }
+        },
+        "@jimp/types": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.5.4.tgz",
+            "integrity": "sha512-nbZXM6TsdpnYHIBd8ZuoxGpvmxc2SqiggY30/bhOP/VJQoDBzm2v/20Ywz5M0snpIK2SdYG52eZPNjfjqUP39w==",
+            "requires": {
+                "@jimp/bmp": "^0.5.4",
+                "@jimp/gif": "^0.5.0",
+                "@jimp/jpeg": "^0.5.4",
+                "@jimp/png": "^0.5.4",
+                "@jimp/tiff": "^0.5.4",
+                "core-js": "^2.5.7",
+                "timm": "^1.6.1"
+            }
+        },
+        "@jimp/utils": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.5.0.tgz",
+            "integrity": "sha512-7H9RFVU+Li2XmEko0GGyzy7m7JjSc7qa+m8l3fUzYg2GtwASApjKF/LSG2AUQCUmDKFLdfIEVjxvKvZUJFEmpw==",
+            "requires": {
+                "core-js": "^2.5.7"
             }
         },
         "ansi-regex": {
@@ -20,49 +297,20 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
+        "any-base": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+            "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
+        },
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
-        "asn1": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-        },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
-        "aws4": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-        },
-        "bcrypt-pbkdf": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-            "optional": true,
-            "requires": {
-                "tweetnacl": "0.14.5"
-            }
-        },
-        "bignumber.js": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.4.0.tgz",
-            "integrity": "sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg="
+        "base64-js": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
         },
         "bluebird": {
             "version": "3.5.1",
@@ -70,32 +318,23 @@
             "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
         "bmp-js": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.0.3.tgz",
-            "integrity": "sha1-ZBE+nHzxICs3btYHvzBibr5XsYo="
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+            "integrity": "sha1-4Fpj95amwf8l9Hcex62twUjAcjM="
         },
-        "boom": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+        "buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+            "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
             "requires": {
-                "hoek": "4.2.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
             }
         },
         "buffer-equal": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
             "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
-        },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "code-point-at": {
             "version": "1.1.0",
@@ -107,14 +346,6 @@
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
             "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
         },
-        "combined-stream": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-            "requires": {
-                "delayed-stream": "1.0.0"
-            }
-        },
         "commander": {
             "version": "2.12.2",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
@@ -125,112 +356,32 @@
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
-        "core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "cryptiles": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-            "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-            "requires": {
-                "boom": "5.2.0"
-            },
-            "dependencies": {
-                "boom": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-                    "requires": {
-                        "hoek": "4.2.0"
-                    }
-                }
-            }
-        },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "requires": {
-                "assert-plus": "1.0.0"
-            }
-        },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        "core-js": {
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+            "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
         },
         "dom-walk": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
             "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
         },
-        "ecc-jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-            "optional": true,
-            "requires": {
-                "jsbn": "0.1.1"
-            }
-        },
-        "es6-promise": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
-        },
         "exif-parser": {
             "version": "0.1.12",
             "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
             "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI="
         },
-        "extend": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-        },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-        },
-        "fast-deep-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-        },
         "file-type": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-            "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
+            "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="
         },
         "for-each": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-            "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
             "requires": {
-                "is-function": "1.0.1"
-            }
-        },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
-        "form-data": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-            "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-            "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "is-callable": "^1.1.3"
             }
         },
         "fs-extra": {
@@ -238,9 +389,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
             "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "gauge": {
@@ -248,22 +399,14 @@
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
             "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-            }
-        },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "requires": {
-                "assert-plus": "1.0.0"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
             }
         },
         "global": {
@@ -271,8 +414,8 @@
             "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
             "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
             "requires": {
-                "min-document": "2.19.0",
-                "process": "0.5.2"
+                "min-document": "^2.19.0",
+                "process": "~0.5.1"
             }
         },
         "graceful-fs": {
@@ -280,62 +423,27 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-        },
-        "har-validator": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-            "requires": {
-                "ajv": "5.3.0",
-                "har-schema": "2.0.0"
-            }
-        },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
-        "hawk": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-            "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-            }
+        "ieee754": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+            "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
         },
-        "hoek": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-            "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-        },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-            }
-        },
-        "ip-regex": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-            "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0="
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
         },
         "is-fullwidth-code-point": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-function": {
@@ -343,127 +451,62 @@
             "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
             "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
         },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
-        "isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-        },
         "jimp": {
-            "version": "0.2.28",
-            "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
-            "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.5.4.tgz",
+            "integrity": "sha512-GIyNJ0a/o8C8Npkpz0MbowxcqOJ+TUQwC3NxxmqvK8B6cWuyPXizVKH7S57hp7J8rniPAYMTRucuwLWVTBb5lw==",
             "requires": {
-                "bignumber.js": "2.4.0",
-                "bmp-js": "0.0.3",
-                "es6-promise": "3.3.1",
-                "exif-parser": "0.1.12",
-                "file-type": "3.9.0",
-                "jpeg-js": "0.2.0",
-                "load-bmfont": "1.3.0",
-                "mime": "1.4.1",
-                "mkdirp": "0.5.1",
-                "pixelmatch": "4.0.2",
-                "pngjs": "3.3.0",
-                "read-chunk": "1.0.1",
-                "request": "2.83.0",
-                "stream-to-buffer": "0.1.0",
-                "tinycolor2": "1.4.1",
-                "url-regex": "3.2.0"
+                "@babel/polyfill": "^7.0.0",
+                "@jimp/custom": "^0.5.4",
+                "@jimp/plugins": "^0.5.4",
+                "@jimp/types": "^0.5.4",
+                "core-js": "^2.5.7"
             }
         },
         "jpeg-js": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.2.0.tgz",
-            "integrity": "sha1-U+RI7J0mPmgyZkZ+lELSxaLvVII="
-        },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "optional": true
-        },
-        "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-        },
-        "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-        },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.4.tgz",
+            "integrity": "sha512-6IzjQxvnlT8UlklNmDXIJMWxijULjqGrzgqc0OG7YadZdvm7KPQ1j0ehmQQHckgEWOfgpptzcnWgESovxudpTA=="
         },
         "jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.11"
-            }
-        },
-        "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
+                "graceful-fs": "^4.1.6"
             }
         },
         "load-bmfont": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.3.0.tgz",
-            "integrity": "sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.0.tgz",
+            "integrity": "sha512-kT63aTAlNhZARowaNYcY29Fn/QYkc52M3l6V1ifRcPewg2lvUZDAj7R6dXjOL9D0sict76op3T5+odumDSF81g==",
             "requires": {
                 "buffer-equal": "0.0.1",
-                "mime": "1.4.1",
-                "parse-bmfont-ascii": "1.0.6",
-                "parse-bmfont-binary": "1.0.6",
-                "parse-bmfont-xml": "1.1.3",
-                "xhr": "2.4.0",
-                "xtend": "4.0.1"
+                "mime": "^1.3.4",
+                "parse-bmfont-ascii": "^1.0.3",
+                "parse-bmfont-binary": "^1.0.5",
+                "parse-bmfont-xml": "^1.1.4",
+                "phin": "^2.9.1",
+                "xhr": "^2.0.1",
+                "xtend": "^4.0.0"
             }
         },
         "lodash": {
-            "version": "4.17.4",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+            "version": "4.17.11",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
         "mime": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-        },
-        "mime-db": {
-            "version": "1.30.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-            "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-        },
-        "mime-types": {
-            "version": "2.1.17",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-            "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-            "requires": {
-                "mime-db": "1.30.0"
-            }
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "min-document": {
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
             "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
             "requires": {
-                "dom-walk": "0.1.1"
+                "dom-walk": "^0.1.0"
             }
         },
         "minimist": {
@@ -484,15 +527,20 @@
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
-        "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "omggif": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.9.tgz",
+            "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8="
+        },
+        "pako": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
         },
         "parse-bmfont-ascii": {
             "version": "1.0.6",
@@ -505,12 +553,12 @@
             "integrity": "sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY="
         },
         "parse-bmfont-xml": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz",
-            "integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
+            "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
             "requires": {
-                "xml-parse-from-string": "1.0.1",
-                "xml2js": "0.4.19"
+                "xml-parse-from-string": "^1.0.0",
+                "xml2js": "^0.4.5"
             }
         },
         "parse-headers": {
@@ -518,81 +566,37 @@
             "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
             "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
             "requires": {
-                "for-each": "0.3.2",
+                "for-each": "^0.3.2",
                 "trim": "0.0.1"
             }
         },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        "phin": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.2.tgz",
+            "integrity": "sha512-j+UOz1qs+k8NlBRws2IF+Qd+YsVKcqIjvYPBEP9IpmhyvLvyN6GTuqsGbsqH3fIgHufqVqLQSttidIgshkgT7w=="
         },
         "pixelmatch": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
             "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
             "requires": {
-                "pngjs": "3.3.0"
+                "pngjs": "^3.0.0"
             }
         },
         "pngjs": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.0.tgz",
-            "integrity": "sha1-H1cwwYnJSTO4G+2iqy+OKFUmOo8="
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.3.tgz",
+            "integrity": "sha512-1n3Z4p3IOxArEs1VRXnZ/RXdfEniAUS9jb68g58FIXMNkPJeZd+Qh4Uq7/e0LVxAQGos1eIUrqrt4FpjdnEd+Q=="
         },
         "process": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
             "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
         },
-        "punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "qs": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-        },
-        "read-chunk": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz",
-            "integrity": "sha1-X2jKswfmY/GZk1J9m1icrORmEZQ="
-        },
-        "request": {
-            "version": "2.83.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-            "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-            }
-        },
-        "safe-buffer": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         },
         "sax": {
             "version": "1.2.4",
@@ -604,123 +608,50 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
-        "sntp": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-            "requires": {
-                "hoek": "4.2.0"
-            }
-        },
-        "sshpk": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-            "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-            }
-        },
-        "stream-to": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stream-to/-/stream-to-0.2.2.tgz",
-            "integrity": "sha1-hDBgmNhf25kLn6MAsbPM9V6O8B0="
-        },
-        "stream-to-buffer": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz",
-            "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
-            "requires": {
-                "stream-to": "0.2.2"
-            }
-        },
         "string-width": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
-        },
-        "stringstream": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
         },
         "strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
+        },
+        "timm": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/timm/-/timm-1.6.1.tgz",
+            "integrity": "sha512-hqDTYi/bWuDxL2i6T3v6nrvkAQ/1Bc060GSkVEQZp02zTSTB4CHSKsOkliequCftQaNRcjRqUZmpGWs5FfhrNg=="
         },
         "tinycolor2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
             "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
         },
-        "tough-cookie": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-            "requires": {
-                "punycode": "1.4.1"
-            }
-        },
         "trim": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
             "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-        },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "requires": {
-                "safe-buffer": "5.1.1"
-            }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "optional": true
         },
         "universalify": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
             "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
         },
-        "url-regex": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
-            "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
+        "utif": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
+            "integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
             "requires": {
-                "ip-regex": "1.0.3"
-            }
-        },
-        "uuid": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-        },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "pako": "^1.0.5"
             }
         },
         "wide-align": {
@@ -728,18 +659,18 @@
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
             "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
             "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2"
             }
         },
         "xhr": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
-            "integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+            "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
             "requires": {
-                "global": "4.3.2",
-                "is-function": "1.0.1",
-                "parse-headers": "2.0.1",
-                "xtend": "4.0.1"
+                "global": "~4.3.0",
+                "is-function": "^1.0.1",
+                "parse-headers": "^2.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "xml-parse-from-string": {
@@ -752,14 +683,14 @@
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
             "requires": {
-                "sax": "1.2.4",
-                "xmlbuilder": "9.0.4"
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
             }
         },
         "xmlbuilder": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
-            "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+            "version": "9.0.7",
+            "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         },
         "xtend": {
             "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
         "colors": "^1.1.2",
         "commander": "^2.12.2",
         "fs-extra": "^4.0.2",
-        "jimp": "^0.2.28",
-        "lodash": "^4.17.4",
+        "jimp": "^0.5.4",
+        "lodash": "^4.17.11",
         "gauge": "^2.7.4"
     },
     "contributors": [


### PR DESCRIPTION
Since iOS and Android keep changing their icon and splash needs, this PR adds the `configPath` option to replace the defaults config for `cordova-res-generator` with your custom ones.

Example for iOS icons:
```javascript
module.exports = {
  platform: 'ios',
  type: 'icon',
  path: 'ios/icon',
  definitions: [
    { name: 'Icon-16.png', size: 16 },
    { name: 'Icon-20.png', size: 20 },
    { name: 'Icon-29.png', size: 29 },
    { name: 'Icon-32.png', size: 32 },
    { name: 'Icon-40.png', size: 40 },
    { name: 'Icon-48.png', size: 48 },
    { name: 'Icon-50.png', size: 50 },
    { name: 'Icon-55.png', size: 55 },
    { name: 'Icon-57.png', size: 57 },
    { name: 'Icon-58.png', size: 58 },
    { name: 'Icon-60.png', size: 60 },
    { name: 'Icon-64.png', size: 64 },
    { name: 'Icon-72.png', size: 72 },
    { name: 'Icon-76.png', size: 76 },
    { name: 'Icon-80.png', size: 80 },
    { name: 'Icon-87.png', size: 87 },
    { name: 'Icon-88.png', size: 88 },
    { name: 'Icon-100.png', size: 100 },
    { name: 'Icon-114.png', size: 114 },
    { name: 'Icon-120.png', size: 120 },
    { name: 'Icon-128.png', size: 128 },
    { name: 'Icon-144.png', size: 144 },
    { name: 'Icon-152.png', size: 152 },
    { name: 'Icon-167.png', size: 167 },
    { name: 'Icon-172.png', size: 172 },
    { name: 'Icon-180.png', size: 180 },
    { name: 'Icon-196.png', size: 196 },
    { name: 'Icon-256.png', size: 256 },
    { name: 'Icon-512.png', size: 512 },
    { name: 'Icon-1024.png', size: 1024 }
  ]
};
```

Some other things in this PR (let me know if you want to remove some of these):

- Upgraded jimp and lodash to prevent dependency vulnerabilities (`npm audit`)
- Replaced `crop` with `cover` for splash generation
- Changed the character for better display `V -> ✓` and `X -> ✗` 