### PR TITLE
Fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ or
                                 (default: ./resources/)
     -I, --makeicon [optional]   option to process icon files only
     -S, --makesplash [optional] option to process splash files only
+    -R, --resize [optional]     option to resize splash screen source image before cropping
     -h, --help                  output usage information
 
 ---

--- a/lib/core/imageManager.js
+++ b/lib/core/imageManager.js
@@ -106,9 +106,15 @@ function transformIcon(imageObjects, outputPath, definition) {
     return defer.promise;
 }
 
-function transformSplash(imageObjects, outputPath, definition) {
+function transformSplash(imageObjects, outputPath, definition, resize) {
     var defer = Q.defer();
     var image = imageObjects.splash.clone();
+
+    if (resize) {
+        // first resize the provided source image down to match the maximum dimention of the current target output
+        var maxDimension = definition.width > definition.height ? definition.width : definition.height;
+        image.resize(maxDimension, maxDimension);
+    }
 
     var x = (image.bitmap.width - definition.width) / 2;
     var y = (image.bitmap.height - definition.height) / 2;

--- a/lib/core/settingsManager.js
+++ b/lib/core/settingsManager.js
@@ -27,31 +27,17 @@ function getCommand(commandLineArguments) {
         .parse(commandLineArguments);
     return {
         version: pjson.version,
-        icon: program.icon,
-        splash: program.splash,
-        outputdir: program.outputdir,
-        makeicon: program.makeicon,
-        makesplash: program.makesplash
+        iconfile: program.icon || path.join('.', 'resources', 'icon.png'),
+        splashfile: program.splash || path.join('.', 'resources', 'splash.png'),
+        platforms: program.platforms,
+        outputdirectory: program.outputdir || path.join('.', 'resources'),
+        makeicon: program.makeicon || (!program.makeicon && !program.makesplash) ? true : false,
+        makesplash: program.makesplash || (!program.makeicon && !program.makesplash) ? true : false,
     };
-}
-
-function computeSettings(command) {
-    // app settings and default values
-    var settings = {
-        version: command.version,
-        iconfile: command.icon || path.join('.', 'resources', 'icon.png'),
-        splashfile: command.splash || path.join('.', 'resources', 'splash.png'),
-        platforms: command.platforms || undefined,
-        outputdirectory: command.outputdir || path.join('.', 'resources'),
-        makeicon: command.makeicon || (!command.makeicon && !command.makesplash) ? true : false,
-        makesplash: command.makesplash || (!command.makeicon && !command.makesplash) ? true : false
-    };
-    return settings;
 }
 
 function makeSettings(commandLineArguments) {
-    var command = getCommand(commandLineArguments);
-    return computeSettings(command);
+    return getCommand(commandLineArguments);
 }
 
 // module exports

--- a/lib/core/settingsManager.js
+++ b/lib/core/settingsManager.js
@@ -24,6 +24,7 @@ function getCommand(commandLineArguments) {
         .option('-o, --outputdir [optional]', 'optional output directory (default: ./resources/)')
         .option('-I, --makeicon [optional]', 'option to process icon files only')
         .option('-S, --makesplash [optional]', 'option to process splash files only')
+        .option('-R, --resize [optional]', 'option to resize splash source image before cropping')
         .parse(commandLineArguments);
     return {
         version: pjson.version,
@@ -33,6 +34,7 @@ function getCommand(commandLineArguments) {
         outputdirectory: program.outputdir || path.join('.', 'resources'),
         makeicon: program.makeicon || (!program.makeicon && !program.makesplash) ? true : false,
         makesplash: program.makesplash || (!program.makeicon && !program.makesplash) ? true : false,
+        resize: program.resize
     };
 }
 

--- a/lib/core/settingsManager.js
+++ b/lib/core/settingsManager.js
@@ -45,7 +45,5 @@ function makeSettings(commandLineArguments) {
 // module exports
 
 module.exports = {
-    'getCommand': getCommand,
-    'computeSettings': computeSettings,
     'makeSettings': makeSettings
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -45,7 +45,7 @@ function generateForImagePlatformDefinition(settings, imageObjects, imagePlatfor
                         transformPromise = transformPromise.then(() => imageManager.transformIcon(imageObjects, outputPath, def));
                         break;
                     case 'splash':
-                        transformPromise = transformPromise.then(() => imageManager.transformSplash(imageObjects, outputPath, def));
+                        transformPromise = transformPromise.then(() => imageManager.transformSplash(imageObjects, outputPath, def, settings.resize));
                         break;
                 }
                 return transformPromise;


### PR DESCRIPTION
ola..

I was battling to find a nice tool to handle icon/splash generation for a few PhoneGap projects when I came across `crgen`. really nifty little utility, by the way, it's been a great help so far. :)

there were a few issues I needed to fix first, so I thought it would be quicker to fork it and make the changes I needed myself. this here PR is just in case you'd like to pull them into your main project as well.

---

I've made changes to the following main points:

* `-p, --platforms` CLI argument is now passed through correctly to the image generation module
* `-R, --resize` CLI argument resizes the provided splash screen source image before cropping
* removed unused "exports" from the `settingsManager` module